### PR TITLE
Added option to specify subdomain (session code) in URL

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -12,7 +12,7 @@
         <meta property="og:image" content="https://astral.duerst.me/images/preview.png">
         <meta property="og:url" content="https://astral.duerst.me/">
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-        <script type="text/javascript" src="scripts/main.js"></script>
+        <script defer type="text/javascript" src="scripts/main.js"></script>
         <link href="https://fonts.googleapis.com/css2?family=BenchNine:wght@300&display=swap" rel="stylesheet">
         <link href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" rel="stylesheet">
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">

--- a/docs/scripts/main.js
+++ b/docs/scripts/main.js
@@ -11,6 +11,8 @@ const lbPan = -97;
 const ubTilt = 32;
 const lbTilt = -32;
 
+const urlParams = new URLSearchParams(window.location.search);
+
 function convertFormToJson(form) {
   var array = jQuery(form).serializeArray();
   var json = {};
@@ -106,3 +108,11 @@ function helpTextHandler(event) {
 $(document).ready(function(){
   $("span.help_text").click(helpTextHandler);
 });
+
+if (urlParams.has("code")) {
+  let code = urlParams.get("code");
+  console.log(`Session code from URL: ${code}`);
+  document.getElementById("subdomain").value = code;
+  const json = convertFormToJson(document.getElementById("form_internal"));
+  updateUrl(json);
+}


### PR DESCRIPTION
## What's in this PR?
This is a pretty straightforward update: the main script will pull the subdomain (session code) from the URL if provided. For example, `https://astral.duerst.me/?code=this-is-a-subdomain` should automatically use that subdomain. This will significantly improve the ease of sharing control during a session.

One other small change to enable this: the main script is now deferred. Otherwise, the main script will be trying to find an element that hasn't loaded yet.

## Known Issues
n/a

# 🐢
